### PR TITLE
manifest email fix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "description": "Renames replay tabs using AI (consumes Caido AI tokens)",
   "author": {
     "name": "Riddle",
-    "email": "",
+    "email": ".",
     "url": "https://github.com/Riddle1001/caido-ai-rename-replay"
   },
   "plugins": [


### PR DESCRIPTION
the `email` field cannot be empty to add this extension to the EvenBetter Extensions library. this should work properly, sorry for that!